### PR TITLE
Fix Symfony 4.3 deprecations on treebuilder root

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('billetel', 'array')
+        $treeBuilder = new TreeBuilder('billetel');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('billetel');
+        }
+
+        $rootNode
             ->children()
             ->scalarNode('api_authorization')->cannotBeEmpty()->isRequired()->end()
             ->scalarNode('api_desk')->cannotBeEmpty()->isRequired()->end()


### PR DESCRIPTION
Symfony 4.3 deprecations - The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "billetel" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.